### PR TITLE
fix: migrates pyyaml  to version 6.0.

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 
 def load_data(file):
 	with open(file, "r") as f:
-		out = yaml.load(f.read())
+		out = yaml.load(f.read(), Loader=yaml.FullLoader)
 		for item in out:
 			item["languages"].sort()
 			item["tags"].sort()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jinja2
+pyyaml>=6.0


### PR DESCRIPTION
yaml.load without Loader is [deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

Pins PyYaml 6.0 and sets yaml FullLoader as Loader.